### PR TITLE
media type

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -186,6 +186,10 @@ class PlaybackControlSkill(MycroftSkill):
     def play_adult(self, message):
         self._play(message, CPSMatchType.ADULT)
 
+    @intent_handler("comic.intent")
+    def play_comic(self, message):
+        self._play(message, CPSMatchType.VISUAL_STORY)
+
     # playback selection
     def _play(self, message, media_type=CPSMatchType.GENERIC):
         self.speak_dialog("just.one.moment", wait=True)

--- a/__init__.py
+++ b/__init__.py
@@ -174,6 +174,10 @@ class PlaybackControlSkill(MycroftSkill):
     def play_tv(self, message):
         self._play(message, CPSMatchType.TV)
 
+    @intent_handler("movie.intent")
+    def play_movie(self, message):
+        self._play(message, CPSMatchType.MOVIE)
+
     @intent_handler("porn.intent")
     def play_adult(self, message):
         self._play(message, CPSMatchType.ADULT)

--- a/__init__.py
+++ b/__init__.py
@@ -302,7 +302,7 @@ class PlaybackControlSkill(MycroftSkill):
             else:
                 self.log.info("   No matches")
                 if media_type != CPSMatchType.GENERIC:
-                    self.log.info("   Resolving generic query fallback")
+                    self.log.info("Resolving generic query fallback")
                     self.bus.emit(message.forward('play:query',
                                                   data={
                                                       "phrase": search_phrase,

--- a/__init__.py
+++ b/__init__.py
@@ -170,6 +170,10 @@ class PlaybackControlSkill(MycroftSkill):
     def play_news(self, message):
         self._play(message, CPSMatchType.NEWS)
 
+    @intent_handler("tv.intent")
+    def play_tv(self, message):
+        self._play(message, CPSMatchType.TV)
+
     # playback selection
     def _play(self, message, media_type=CPSMatchType.GENERIC):
         self.speak_dialog("just.one.moment", wait=True)

--- a/__init__.py
+++ b/__init__.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+import random
 from adapt.intent import IntentBuilder
 from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.skills.audioservice import AudioService
-from mycroft.audio import wait_while_speaking
+from mycroft.skills.common_play_skill import CPSMatchType
 from os.path import join, exists
 from threading import Lock
 
@@ -136,25 +137,45 @@ class PlaybackControlSkill(MycroftSkill):
         else:
             return False
 
-    @intent_handler(IntentBuilder('').require('Play').require('Phrase'))
-    def play(self, message):
-        self.speak_dialog("just.one.moment")
+    # generic play intents
+    @intent_handler("play.intent")
+    def generic_play(self, message):
+        self._play(message, CPSMatchType.GENERIC)
 
-        # Remove everything up to and including "Play"
-        # NOTE: This requires a Play.voc which holds any synomyms for 'Play'
-        #       and a .rx that contains each of those synonyms.  E.g.
-        #  Play.voc
-        #      play
-        #      bork
-        #  phrase.rx
-        #      play (?P<Phrase>.*)
-        #      bork (?P<Phrase>.*)
-        # This really just hacks around limitations of the Adapt regex system,
-        # which will only return the first word of the target phrase
-        utt = message.data.get('utterance')
-        phrase = re.sub('^.*?' + message.data['Play'], '', utt).strip()
-        self.log.info("Resolving Player for: "+phrase)
-        wait_while_speaking()
+    @intent_handler("music.intent")
+    def play_music(self, message):
+        self._play(message, CPSMatchType.MUSIC)
+
+    @intent_handler("video.intent")
+    def play_video(self, message):
+        self._play(message, CPSMatchType.VIDEO)
+
+    @intent_handler("audiobook.intent")
+    def play_audiobook(self, message):
+        self._play(message, CPSMatchType.AUDIOBOOK)
+
+    @intent_handler("game.intent")
+    def play_game(self, message):
+        self._play(message, CPSMatchType.GAME)
+
+    @intent_handler("radio.intent")
+    def play_radio(self, message):
+        self._play(message, CPSMatchType.RADIO)
+
+    @intent_handler("podcast.intent")
+    def play_podcast(self, message):
+        self._play(message, CPSMatchType.PODCAST)
+
+    @intent_handler("news.intent")
+    def play_news(self, message):
+        self._play(message, CPSMatchType.NEWS)
+
+    # playback selection
+    def _play(self, message, media_type=CPSMatchType.GENERIC):
+        self.speak_dialog("just.one.moment", wait=True)
+        phrase = message.data.get("query", "")
+        self.log.info("Resolving {media} Player for: {query}".format(
+            media=media_type, query=phrase))
         self.enclosure.mouth_think()
 
         # Now we place a query on the messsagebus for anyone who wants to
@@ -178,10 +199,13 @@ class PlaybackControlSkill(MycroftSkill):
         #
         self.query_replies[phrase] = []
         self.query_extensions[phrase] = []
-        self.bus.emit(message.forward('play:query', data={"phrase": phrase}))
+
+        self.bus.emit(message.forward('play:query',
+                                      data={"phrase": phrase,
+                                            "media_type": media_type}))
 
         self.schedule_event(self._play_query_timeout, 1,
-                            data={"phrase": phrase},
+                            data={"phrase": phrase, "media_type": media_type},
                             name='PlayQueryTimeout')
 
     def handle_play_query_response(self, message):

--- a/__init__.py
+++ b/__init__.py
@@ -174,6 +174,10 @@ class PlaybackControlSkill(MycroftSkill):
     def play_tv(self, message):
         self._play(message, CPSMatchType.TV)
 
+    @intent_handler("porn.intent")
+    def play_adult(self, message):
+        self._play(message, CPSMatchType.ADULT)
+
     # playback selection
     def _play(self, message, media_type=CPSMatchType.GENERIC):
         self.speak_dialog("just.one.moment", wait=True)

--- a/locale/en-us/Play.voc
+++ b/locale/en-us/Play.voc
@@ -1,3 +1,0 @@
-play
-start
-bork

--- a/locale/en-us/audiobook.intent
+++ b/locale/en-us/audiobook.intent
@@ -1,0 +1,5 @@
+(play|start|read) (audiobook|audio book|book|radio theatre|audio theatre|radio drama) {{query}}
+(read|audiobook|audio book|radio theatre|audio theatre|radio drama) {{query}}
+(play|start|read) {{query}} (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)
+(play|start|read) (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)
+{{query}} (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)

--- a/locale/en-us/audiobook.intent
+++ b/locale/en-us/audiobook.intent
@@ -1,5 +1,5 @@
-(play|start|read) (audiobook|audio book|book|radio theatre|audio theatre|radio drama) {{query}}
-(read|audiobook|audio book|radio theatre|audio theatre|radio drama) {{query}}
-(play|start|read) {{query}} (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)
-(play|start|read) (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)
-{{query}} (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)
+(play|start|read) (audiobook|audio book|book|radio theatre|audio theatre|radio drama|audio drama) {{query}}
+(read|audiobook|audio book|radio theatre|audio theatre|radio drama|audio drama) {{query}}
+(play|start|read) {{query}} (audiobook|audio book|reading|radio theatre|audio theatre|radio drama|audio drama)
+(play|start|read) (audiobook|audio book|reading|radio theatre|audio theatre|radio drama|audio drama)
+{{query}} (audiobook|audio book|reading|radio theatre|audio theatre|radio drama|audio drama)

--- a/locale/en-us/comic.intent
+++ b/locale/en-us/comic.intent
@@ -1,0 +1,3 @@
+(play|start) (comic|motion comic|visual story|visual comic|motion comic|animated comic) {{query}}
+(play|start) {{query}} (comic|motion comic|visual story|visual comic|motion comic|animated comic)
+(play|start) (comic|motion comic|visual story|visual comic|motion comic|animated comic)

--- a/locale/en-us/game.intent
+++ b/locale/en-us/game.intent
@@ -1,0 +1,2 @@
+(play|start) game {{query}}
+(play|start) (some game|game|a game)

--- a/locale/en-us/movie.intent
+++ b/locale/en-us/movie.intent
@@ -1,3 +1,3 @@
-(play|start) (movie|movies) {{query}}
-(play|start) {{query}} (movie|movies)
-(play|start) (a movie|movie|movies)
+(play|start) (movie|movies|film) {{query}}
+(play|start) {{query}} (movie|movies|film|films)
+(play|start) (a movie|movie|movies|film|films)

--- a/locale/en-us/movie.intent
+++ b/locale/en-us/movie.intent
@@ -1,0 +1,3 @@
+(play|start) (movie|movies) {{query}}
+(play|start) {{query}} (movie|movies)
+(play|start) (a movie|movie|movies)

--- a/locale/en-us/movietrailer.intent
+++ b/locale/en-us/movietrailer.intent
@@ -1,0 +1,3 @@
+(play|start) (trailer|movie preview) {{query}}
+(play|start) {{query}} (trailer|movie preview)
+(play|start) (a movie|movie|movies|film|films) (trailer|preview)

--- a/locale/en-us/music.intent
+++ b/locale/en-us/music.intent
@@ -1,0 +1,3 @@
+(play|start) (music|song) {{query}}
+(play|start) (music|song)
+(play|start) (some|a) (music|song)

--- a/locale/en-us/news.intent
+++ b/locale/en-us/news.intent
@@ -1,0 +1,3 @@
+(play|start) (news|news station) {{query}}
+(play|start) {{query}} (news|news station)
+(play|start) (the news|news|news station|some news)

--- a/locale/en-us/phrase.rx
+++ b/locale/en-us/phrase.rx
@@ -1,3 +1,0 @@
-play (?P<Phrase>.*)
-start (?P<Phrase>.*)
-bork (?P<Phrase>.*)

--- a/locale/en-us/play.intent
+++ b/locale/en-us/play.intent
@@ -1,0 +1,1 @@
+(play|start) {{query}}

--- a/locale/en-us/podcast.intent
+++ b/locale/en-us/podcast.intent
@@ -1,0 +1,3 @@
+(play|start) (pod cast|podcast) {{query}}
+(play|start) {{query}} (pod cast|podcast)
+(play|start) (pod cast|podcast)

--- a/locale/en-us/porn.intent
+++ b/locale/en-us/porn.intent
@@ -1,0 +1,3 @@
+(play|start) porn {{query}}
+(play|start) {{query}} porn
+(play|start) porn

--- a/locale/en-us/radio.intent
+++ b/locale/en-us/radio.intent
@@ -1,0 +1,3 @@
+(play|start) (radio|radio station|internet radio|web radio) {{query}}
+(play|start) {{query}} (radio|radio station|internet radio|web radio)
+(play|start) (the radio|the radio station|radio|radio station|internet radio|web radio)

--- a/locale/en-us/tv.intent
+++ b/locale/en-us/tv.intent
@@ -1,3 +1,3 @@
-(play|start) (tv|ip tv|network television|television|ip television) {{query}}
-(play|start) {{query}} (tv|ip tv|network television|television|ip television)
-(play|start) (tv|ip tv|network television|television|ip television)
+(play|start) (tv|ip tv|network television|television|ip television|channel|tv channel) {{query}}
+(play|start) {{query}} (tv|ip tv|network television|television|ip television|channel|tv channel)
+(play|start) (tv|ip tv|network television|television|ip television|tv channel)

--- a/locale/en-us/tv.intent
+++ b/locale/en-us/tv.intent
@@ -1,0 +1,3 @@
+(play|start) (tv|ip tv|network television|television|ip television) {{query}}
+(play|start) {{query}} (tv|ip tv|network television|television|ip television)
+(play|start) (tv|ip tv|network television|television|ip television)

--- a/locale/en-us/video.intent
+++ b/locale/en-us/video.intent
@@ -1,0 +1,3 @@
+(play|start) video {{query}}
+(play|start) {{query}} (with video|video)
+(play|start) video


### PR DESCRIPTION
possible solution for https://github.com/MycroftAI/mycroft-core/issues/2658

companion PR https://github.com/MycroftAI/mycroft-core/pull/2660

NOTE: this will break lang support except for en-us, this is because of migration from adapt to padatious to get rid of the ugly regex hack

To test 
install https://github.com/JarbasSkills/skill-hppodcraft/tree/cps_mediatype and verify 
- "read the call of cthulhu" uses common play with media type audiobook, 
- "play lovecraft podcast" should use podcast media type
- "play {story_name}" should trigger with generic media type
- "read lovecraft" should tie with skill-epic-horror-theatre if using  #36

install https://github.com/JarbasSkills/skil-old-world-radio/tree/cps_media_type and verify
- only triggers with media type radio
- "play vintage radio", "play old world radio"
- "play some radio" should trigger with low confidence


install https://github.com/MycroftAI/skill-npr-news/pull/90
- verify "play the news" triggers default feed with type news
- verify "play {station_name} news" triggers news station with type news
- "play {station_name}" should trigger with type generic

install https://github.com/JarbasSkills/skill-epic-horror-theatre/tree/feat/cps_media
- "read innsmouth" uses common play with media type audiobook, 
- "start audio drama" low confidence with media type audiobook, 
- "play the mountains of madness" should trigger with generic media type
- "read lovecraft" should tie with skill-hppodcraft if using  #36
