### PR TITLE
import wait_while_speaking from new module

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,7 @@ import re
 from adapt.intent import IntentBuilder
 from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.skills.audioservice import AudioService
-from mycroft.util import wait_while_speaking
+from mycroft.audio import wait_while_speaking
 from os.path import join, exists
 from threading import Lock
 


### PR DESCRIPTION
Switch import of wait_while_speaking from deprecated location to new mycroft.audio module.

No change in behaviour just silences a deprecation warning and prepares for eventual removal.