### PR TITLE
Feat/resume playback common play

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -297,6 +297,10 @@ class PlaybackControlSkill(MycroftSkill):
         elif status == CPSTrackStatus.QUEUED_AUDIOSERVICE:
             # audio service is handling playback and this is in playlist
             self.playback_data["playlist"].append(data)
+        elif status == CPSTrackStatus.PAUSED:
+            # media is not being played, but can be resumed anytime
+            # a new PLAYING status should be sent once playback resumes
+            pass
         elif status == CPSTrackStatus.BUFFERING:
             # media is buffering, might want to show in ui
             # a new PLAYING status should be sent once playback resumes

--- a/__init__.py
+++ b/__init__.py
@@ -389,7 +389,9 @@ class PlaybackControlSkill(CommonPlaySkill):
     # handle "play {media_type}" generic queries to mean "resume"
     def CPS_match_query_phrase(self, phrase, media_type):
         if self.playback_status == CPSTrackStatus.PAUSED:
-            if not phrase.strip() or self.voc_match(phrase, "Resume"):
+            if not phrase.strip() or \
+                    self.voc_match(phrase, "Resume")  or \
+                    self.voc_match(phrase, "Play"):
                 return (phrase, CPSMatchLevel.EXACT, self.playback_data)
         return None
 

--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,7 @@ class PlaybackControlSkill(MycroftSkill):
         self.query_extensions = {}  # maintains query timeout extensions
         self.has_played = False
         self.lock = Lock()
+        self.playback_status = CPSTrackStatus.END_OF_MEDIA
         self.playback_data = {"playing": None,
                               "playlist": [],
                               "disambiguation": []}
@@ -104,6 +105,7 @@ class PlaybackControlSkill(MycroftSkill):
         self.playback_data = {"playing": None,
                               "playlist": [],
                               "disambiguation": []}
+        self.playback_status = CPSTrackStatus.END_OF_MEDIA
 
     @intent_handler(IntentBuilder('').require('Next').require("Track"))
     def handle_next(self, message):
@@ -279,12 +281,15 @@ class PlaybackControlSkill(MycroftSkill):
         if status == CPSTrackStatus.PLAYING:
             # skill is handling playback internally
             self.update_current_song(message.data)
+            self.playback_status = status
         elif status == CPSTrackStatus.PLAYING_AUDIOSERVICE:
             # audio service is handling playback
             self.update_current_song(message.data)
+            self.playback_status = status
         elif status == CPSTrackStatus.PLAYING_GUI:
             # gui is handling playback
             self.update_current_song(message.data)
+            self.playback_status = status
         elif status == CPSTrackStatus.DISAMBIGUATION:
             # alternative results
             self.playback_data["disambiguation"].append(data)
@@ -300,18 +305,18 @@ class PlaybackControlSkill(MycroftSkill):
         elif status == CPSTrackStatus.PAUSED:
             # media is not being played, but can be resumed anytime
             # a new PLAYING status should be sent once playback resumes
-            pass
+            self.playback_status = status
         elif status == CPSTrackStatus.BUFFERING:
             # media is buffering, might want to show in ui
             # a new PLAYING status should be sent once playback resumes
-            pass
+            self.playback_status = status
         elif status == CPSTrackStatus.STALLED:
             # media is stalled, might want to show in ui
             # a new PLAYING status should be sent once playback resumes
-            pass
+            self.playback_status = status
         elif status == CPSTrackStatus.END_OF_MEDIA:
             # if we add a repeat/loop flag this is the place to check for it
-            pass
+            self.playback_status = status
 
 
 def create_skill():

--- a/__init__.py
+++ b/__init__.py
@@ -386,12 +386,11 @@ class PlaybackControlSkill(CommonPlaySkill):
         self.bus.emit(message.reply('play:status.response',
                                     self.playback_data))
 
-    # handle "play music" generic queries to mean "resume"
+    # handle "play {media_type}" generic queries to mean "resume"
     def CPS_match_query_phrase(self, phrase, media_type):
-        if self.playback_status == CPSTrackStatus.PAUSED and not phrase.strip():
-            return (phrase, CPSMatchLevel.EXACT, self.playback_data)
-        if self.voc_match(phrase, "Resume") and not phrase.strip():
-            return (phrase, CPSMatchLevel.EXACT, self.playback_data)
+        if self.playback_status == CPSTrackStatus.PAUSED:
+            if not phrase.strip() or self.voc_match(phrase, "Resume"):
+                return (phrase, CPSMatchLevel.EXACT, self.playback_data)
         return None
 
     def CPS_start(self, phrase, data):

--- a/__init__.py
+++ b/__init__.py
@@ -191,7 +191,10 @@ class PlaybackControlSkill(CommonPlaySkill):
     # playback selection
     def _play(self, message, media_type=CPSMatchType.GENERIC):
         phrase = message.data.get("query", "")
-        if phrase:
+
+        will_resume = self.playback_status == CPSTrackStatus.PAUSED \
+                      and not bool(phrase.strip())
+        if not will_resume:
             # empty string means "resume" will be used,
             # speech sounds wrong in that case
             self.speak_dialog("just.one.moment", wait=True)
@@ -292,10 +295,14 @@ class PlaybackControlSkill(CommonPlaySkill):
 
                 # invoke best match
                 self.gui.show_page("controls.qml", override_idle=True)
+
                 self.log.info("Playing with: {}".format(best["skill_id"]))
+
+                will_resume = self.playback_status == CPSTrackStatus.PAUSED \
+                              and not bool(search_phrase.strip())
                 start_data = {"skill_id": best["skill_id"],
                               "phrase": search_phrase,
-                              "stop_audio": bool(search_phrase.strip()),
+                              "trigger_stop": not will_resume,
                               "callback_data": best.get("callback_data")}
                 self.bus.emit(message.forward('play:start', start_data))
                 self.has_played = True

--- a/__init__.py
+++ b/__init__.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+import random
 from adapt.intent import IntentBuilder
 from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.skills.audioservice import AudioService
-from mycroft.audio import wait_while_speaking
+from mycroft.skills.common_play_skill import CPSMatchType
 from os.path import join, exists
 from threading import Lock
 
@@ -136,25 +137,45 @@ class PlaybackControlSkill(MycroftSkill):
         else:
             return False
 
-    @intent_handler(IntentBuilder('').require('Play').require('Phrase'))
-    def play(self, message):
-        self.speak_dialog("just.one.moment")
+    # generic play intents
+    @intent_handler("play.intent")
+    def generic_play(self, message):
+        self._play(message, CPSMatchType.GENERIC)
 
-        # Remove everything up to and including "Play"
-        # NOTE: This requires a Play.voc which holds any synomyms for 'Play'
-        #       and a .rx that contains each of those synonyms.  E.g.
-        #  Play.voc
-        #      play
-        #      bork
-        #  phrase.rx
-        #      play (?P<Phrase>.*)
-        #      bork (?P<Phrase>.*)
-        # This really just hacks around limitations of the Adapt regex system,
-        # which will only return the first word of the target phrase
-        utt = message.data.get('utterance')
-        phrase = re.sub('^.*?' + message.data['Play'], '', utt).strip()
-        self.log.info("Resolving Player for: "+phrase)
-        wait_while_speaking()
+    @intent_handler("music.intent")
+    def play_music(self, message):
+        self._play(message, CPSMatchType.MUSIC)
+
+    @intent_handler("video.intent")
+    def play_video(self, message):
+        self._play(message, CPSMatchType.VIDEO)
+
+    @intent_handler("audiobook.intent")
+    def play_audiobook(self, message):
+        self._play(message, CPSMatchType.AUDIOBOOK)
+
+    @intent_handler("game.intent")
+    def play_game(self, message):
+        self._play(message, CPSMatchType.GAME)
+
+    @intent_handler("radio.intent")
+    def play_radio(self, message):
+        self._play(message, CPSMatchType.RADIO)
+
+    @intent_handler("podcast.intent")
+    def play_podcast(self, message):
+        self._play(message, CPSMatchType.PODCAST)
+
+    @intent_handler("news.intent")
+    def play_news(self, message):
+        self._play(message, CPSMatchType.NEWS)
+
+    # playback selection
+    def _play(self, message, media_type=CPSMatchType.GENERIC):
+        self.speak_dialog("just.one.moment", wait=True)
+        phrase = message.data.get("query", "")
+        self.log.info("Resolving {media} Player for: {query}".format(
+            media=media_type, query=phrase))
         self.enclosure.mouth_think()
 
         # Now we place a query on the messsagebus for anyone who wants to
@@ -178,10 +199,13 @@ class PlaybackControlSkill(MycroftSkill):
         #
         self.query_replies[phrase] = []
         self.query_extensions[phrase] = []
-        self.bus.emit(message.forward('play:query', data={"phrase": phrase}))
+
+        self.bus.emit(message.forward('play:query',
+                                      data={"phrase": phrase,
+                                            "media_type": media_type}))
 
         self.schedule_event(self._play_query_timeout, 1,
-                            data={"phrase": phrase},
+                            data={"phrase": phrase, "media_type": media_type},
                             name='PlayQueryTimeout')
 
     def handle_play_query_response(self, message):

--- a/locale/en-us/Play.voc
+++ b/locale/en-us/Play.voc
@@ -1,0 +1,2 @@
+play
+start

--- a/locale/en-us/Play.voc
+++ b/locale/en-us/Play.voc
@@ -1,3 +1,0 @@
-play
-start
-bork

--- a/locale/en-us/audiobook.intent
+++ b/locale/en-us/audiobook.intent
@@ -1,0 +1,5 @@
+(play|start|read) (audiobook|audio book|book|radio theatre|audio theatre|radio drama) {{query}}
+(read|audiobook|audio book|radio theatre|audio theatre|radio drama) {{query}}
+(play|start|read) {{query}} (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)
+(play|start|read) (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)
+{{query}} (audiobook|audio book|reading|radio theatre|audio theatre|radio drama)

--- a/locale/en-us/game.intent
+++ b/locale/en-us/game.intent
@@ -1,0 +1,2 @@
+(play|start) game {{query}}
+(play|start) (some game|game|a game)

--- a/locale/en-us/music.intent
+++ b/locale/en-us/music.intent
@@ -1,0 +1,3 @@
+(play|start) (music|song) {{query}}
+(play|start) (music|song)
+(play|start) (some|a) (music|song)

--- a/locale/en-us/news.intent
+++ b/locale/en-us/news.intent
@@ -1,0 +1,3 @@
+(play|start) (news|news station) {{query}}
+(play|start) {{query}} (news|news station)
+(play|start) (the news|news|news station|some news)

--- a/locale/en-us/phrase.rx
+++ b/locale/en-us/phrase.rx
@@ -1,3 +1,0 @@
-play (?P<Phrase>.*)
-start (?P<Phrase>.*)
-bork (?P<Phrase>.*)

--- a/locale/en-us/play.intent
+++ b/locale/en-us/play.intent
@@ -1,0 +1,1 @@
+(play|start) {{query}}

--- a/locale/en-us/podcast.intent
+++ b/locale/en-us/podcast.intent
@@ -1,0 +1,3 @@
+(play|start) (pod cast|podcast) {{query}}
+(play|start) {{query}} (pod cast|podcast)
+(play|start) (pod cast|podcast)

--- a/locale/en-us/radio.intent
+++ b/locale/en-us/radio.intent
@@ -1,0 +1,3 @@
+(play|start) (radio|radio station|internet radio|web radio) {{query}}
+(play|start) {{query}} (radio|radio station|internet radio|web radio)
+(play|start) (the radio|the radio station|radio|radio station|internet radio|web radio)

--- a/locale/en-us/video.intent
+++ b/locale/en-us/video.intent
@@ -1,0 +1,3 @@
+(play|start) video {{query}}
+(play|start) {{query}} (with video|video)
+(play|start) video


### PR DESCRIPTION
solves #18 

depends on https://github.com/MycroftAI/mycroft-core/pull/2660 and https://github.com/MycroftAI/mycroft-core/pull/2674

includes/depends on #35 #32  - will need rebase before merging

This refactors the existing adapt intents to not capture too much:
- next/prev intents now need a context to ensure a playlist exists
- resume intent now needs a context to ensure playback is occurring

The skill will now handle common play queries, if the current status is paused:
- if the phrase is an empty string it means the intent was a generic match (play music/read audiobook...)
- if the phrae matches Resume.voc or Play.voc  playback is resumed

This required some changes in core to avoid a call to stop audio service (which prevented resuming)